### PR TITLE
Create pretrained model dir if needed; Replace obsolete get_weights

### DIFF
--- a/proteinbert/existing_model_loading.py
+++ b/proteinbert/existing_model_loading.py
@@ -37,6 +37,8 @@ def load_pretrained_model(local_model_dump_dir = DEFAULT_LOCAL_MODEL_DUMP_DIR, l
                     raise ValueError('User wished to cancel.')
         
         downloaded_file_name = os.path.basename(urlparse(remote_model_dump_url).path)
+        if not os.path.exists(local_model_dump_dir):
+            os.mkdir(local_model_dump_dir)
         downloaded_file_path = os.path.join(local_model_dump_dir, downloaded_file_name)
         assert not os.path.exists(downloaded_file_path), 'Cannot download into an already existing file: %s' % downloaded_file_path
         

--- a/proteinbert/model_generation.py
+++ b/proteinbert/model_generation.py
@@ -31,8 +31,8 @@ class ModelGenerator:
         self.update_state(model)
         
     def update_state(self, model):
-        self.model_weights = copy_weights(model.get_weights())
-        self.optimizer_weights = copy_weights(model.optimizer.get_weights())
+        self.model_weights = copy_weights([w.numpy() for w in model.variables])
+        self.optimizer_weights = copy_weights([w.numpy() for w in model.optimizer.variables()])
         
     def _init_weights(self, model):
     
@@ -45,7 +45,7 @@ class ModelGenerator:
             model.set_weights(copy_weights(self.model_weights))
         
         if self.optimizer_weights is not None:
-            if len(self.optimizer_weights) == len(model.optimizer.get_weights()):
+            if len(self.optimizer_weights) == len(model.optimizer.variables()):
                 model.optimizer.set_weights(copy_weights(self.optimizer_weights))
             else:
                 log('Incompatible number of optimizer weights - will not initialize them.')


### PR DESCRIPTION
get_weights API doesn't exist on latest TensorFlow. Replaced by model / optimizer variables.